### PR TITLE
ISSUE 3 - Criar regras de campos obrigatórios no GetBoletoById

### DIFF
--- a/src/main/java/com/br/sellers/fitbank/mock/service/paymentslip/GetPaymentSlipByIdService.java
+++ b/src/main/java/com/br/sellers/fitbank/mock/service/paymentslip/GetPaymentSlipByIdService.java
@@ -8,6 +8,8 @@ import com.br.sellers.fitbank.mock.gateway.model.response.paymentslip.GetPayment
 import com.br.sellers.fitbank.mock.service.ServiceBaseImpl;
 import com.google.gson.Gson;
 
+import java.util.Map;
+
 public class GetPaymentSlipByIdService extends ServiceBaseImpl {
 
     @Override
@@ -27,4 +29,9 @@ public class GetPaymentSlipByIdService extends ServiceBaseImpl {
         modelResponde.setBoleto(new GetPaymentSlipDetailsItensResponseModel());
     }
 
+    @Override
+    protected void validadeFields(BasicRequestModel request, Map<String, Object> errors) {
+        GetPaymentSlipDetailsRequestModel model = (GetPaymentSlipDetailsRequestModel) request;
+        validadeField(model.getDocumentNumber(), "DocumentNumber", "DocumentNumber é obrigatório", errors);
+    }
 }

--- a/src/test/java/com/br/sellers/fitbank/mock/service/paymentslip/GetPaymentSlipByIdServiceTest.java
+++ b/src/test/java/com/br/sellers/fitbank/mock/service/paymentslip/GetPaymentSlipByIdServiceTest.java
@@ -15,7 +15,7 @@ class GetPaymentSlipByIdServiceTest {
 
     @ParameterizedTest
     @NullAndEmptySource
-    void executarValidacaoVazio(final String documentNumber) throws JsonProcessingException {
+    void shouldGetNullWhenPassingInvalidDocumentNumber(final String documentNumber) throws JsonProcessingException {
         final GetPaymentSlipDetailsRequestModel request = new GetPaymentSlipDetailsRequestModel();
         request.setMethod("GetBoletoById");
         request.setPartnerId(12345L);

--- a/src/test/java/com/br/sellers/fitbank/mock/service/paymentslip/GetPaymentSlipByIdServiceTest.java
+++ b/src/test/java/com/br/sellers/fitbank/mock/service/paymentslip/GetPaymentSlipByIdServiceTest.java
@@ -13,6 +13,8 @@ import java.util.Map;
 
 class GetPaymentSlipByIdServiceTest {
 
+    private final ServiceBase getPaymentSlipByIdService = new GetPaymentSlipByIdService();
+
     @ParameterizedTest
     @NullAndEmptySource
     void shouldGetNullWhenPassingInvalidDocumentNumber(final String documentNumber) throws JsonProcessingException {
@@ -25,9 +27,7 @@ class GetPaymentSlipByIdServiceTest {
         request.setDocumentNumber(documentNumber);
 
         final String requestBody = new Gson().toJson(request);
-
-        final ServiceBase service = new GetPaymentSlipByIdService();
-        final BasicResponseModel response = service.execute(requestBody, "");
+        final BasicResponseModel response = getPaymentSlipByIdService.execute(requestBody, "");
 
         Assertions.assertNotNull(response);
         Assertions.assertNotNull(response.getValidation());

--- a/src/test/java/com/br/sellers/fitbank/mock/service/paymentslip/GetPaymentSlipByIdServiceTest.java
+++ b/src/test/java/com/br/sellers/fitbank/mock/service/paymentslip/GetPaymentSlipByIdServiceTest.java
@@ -1,0 +1,40 @@
+package com.br.sellers.fitbank.mock.service.paymentslip;
+
+import com.br.sellers.fitbank.mock.gateway.model.request.paymentslip.GetPaymentSlipDetailsRequestModel;
+import com.br.sellers.fitbank.mock.gateway.model.response.BasicResponseModel;
+import com.br.sellers.fitbank.mock.service.ServiceBase;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.util.Map;
+
+class GetPaymentSlipByIdServiceTest {
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void executarValidacaoVazio(final String documentNumber) throws JsonProcessingException {
+        final GetPaymentSlipDetailsRequestModel request = new GetPaymentSlipDetailsRequestModel();
+        request.setMethod("GetBoletoById");
+        request.setPartnerId(12345L);
+        request.setBusinessUnitId(1234567890L);
+
+        request.setMktPlaceId(1L);
+        request.setDocumentNumber(documentNumber);
+
+        final String requestBody = new Gson().toJson(request);
+
+        final ServiceBase service = new GetPaymentSlipByIdService();
+        final BasicResponseModel response = service.execute(requestBody, "");
+
+        Assertions.assertNotNull(response);
+        Assertions.assertNotNull(response.getValidation());
+        Assertions.assertEquals(1, response.getValidation().length);
+
+        final Map<String, String> validation = (Map<String, String>) response.getValidation()[0];
+        Assertions.assertTrue(validation.containsKey("DocumentNumber"));
+        Assertions.assertEquals("DocumentNumber é obrigatório", validation.get("DocumentNumber"));
+    }
+}


### PR DESCRIPTION
## Foi testado no Java 1.8 (Leia a Readme para entender)?
- [x] Sim

```
openjdk version "1.8.0_292"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_292-b10)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.292-b10, mixed mode)
```
 
## O que era pra ser feito?
Incluido regras de campos obrigatórios de acordo com a documentação https://fitbank.com.br/developer/#api-Boleto-GetBoletoById

## Issue
[Criar regras de campos obrigatórios no GetBoletoById](https://github.com/Sellers-Community/fitbank-mock/issues/3)

## Tipo de alteração

Exclua as opções que não são relevantes.
- [X] Novo recurso
- [ ] Correção de bug

## Como isso foi testado?

- Através do teste unitário: ```GetPaymentSlipByIdServiceTest```

- Executando as seguintes chamadas para o endpoint principal:

```
// DocumentNumber vazio
curl --request POST \
  --url http://localhost:8031/main/execute \
  --header 'content-type: application/json' \
  --data '{
	"Method": "GetBoletoById",
	"PartnerId": 12345,
	"BusinessUnitId": 1234567890,
	"DocumentNumber": ""
}'

// DocumentNumber nulo
curl --request POST \
  --url http://localhost:8031/main/execute \
  --header 'content-type: application/json' \
  --data '{
	"Method": "GetBoletoById",
	"PartnerId": 12345,
	"BusinessUnitId": 1234567890,
	"DocumentNumber": null
}'

// DocumentNumber não informado
curl --request POST \
  --url http://localhost:8031/main/execute \
  --header 'content-type: application/json' \
  --data '{
	"Method": "GetBoletoById",
	"PartnerId": 12345,
	"BusinessUnitId": 1234567890
}'
```

