### PR TITLE
ISSUE 4 - Criar regras de campos obrigatórios no InternalTransfer

### DIFF
--- a/src/main/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleService.java
+++ b/src/main/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleService.java
@@ -10,6 +10,7 @@ import com.google.gson.Gson;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 public class CreateInternalTransferSimpleService extends ServiceBaseImpl {
@@ -40,4 +41,15 @@ public class CreateInternalTransferSimpleService extends ServiceBaseImpl {
         modelResponde.setInternalTransfers(new Gson().toJson(list));
     }
 
+    @Override
+    protected void validadeFields(BasicRequestModel request, Map<String, Object> errors) {
+        InternalTransferSimpleRequestModel model = (InternalTransferSimpleRequestModel) request;
+        validadeField(model.getValue(), "Value", "Value é obrigatório", errors);
+        validadeField(model.getRateValue(), "RateValue", "RateValue é obrigatório", errors);
+        validadeField(model.getIdentifier(), "Identifier", "Identifier é obrigatório", errors);
+        validadeField(model.getToTaxNumber(), "ToTaxNumber", "ToTaxNumber é obrigatório", errors);
+        validadeField(model.getDescription(), "Description", "Description é obrigatório", errors);
+        validadeField(model.getTransferDate(), "TransferDate", "TransferDate é obrigatório", errors);
+        validadeField(model.getFromTaxNumber(), "FromTaxNumber", "FromTaxNumber é obrigatório", errors);
+    }
 }

--- a/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
+++ b/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
@@ -6,6 +6,7 @@ import com.br.sellers.fitbank.mock.service.ServiceBase;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
@@ -33,6 +34,14 @@ class CreateInternalTransferSimpleServiceTest {
         request.setToTaxNumber(toTaxNumber);
 
         createInternalTransferSimpleServiceExecuteAssertions(request, "ToTaxNumber");
+    }
+
+    @Test
+    void shouldGetNullWhenPassingInvalidValue() throws JsonProcessingException {
+        final InternalTransferSimpleRequestModel request = request();
+        request.setValue(null);
+
+        createInternalTransferSimpleServiceExecuteAssertions(request, "Value");
     }
 
     private void createInternalTransferSimpleServiceExecuteAssertions(final InternalTransferSimpleRequestModel request,

--- a/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
+++ b/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
@@ -61,6 +61,15 @@ class CreateInternalTransferSimpleServiceTest {
         createInternalTransferSimpleServiceExecuteAssertions(request, "TransferDate");
     }
 
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldGetNullWhenPassingInvalidIdentifier(final String identifier) throws JsonProcessingException {
+        final InternalTransferSimpleRequestModel request = request();
+        request.setIdentifier(identifier);
+
+        createInternalTransferSimpleServiceExecuteAssertions(request, "Identifier");
+    }
+
     private void createInternalTransferSimpleServiceExecuteAssertions(final InternalTransferSimpleRequestModel request,
                                                                       final String field) throws JsonProcessingException {
         final String requestBody = new Gson().toJson(request);

--- a/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
+++ b/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
@@ -52,6 +52,15 @@ class CreateInternalTransferSimpleServiceTest {
         createInternalTransferSimpleServiceExecuteAssertions(request, "RateValue");
     }
 
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldGetNullWhenPassingInvalidTransferDate(final String transferDate) throws JsonProcessingException {
+        final InternalTransferSimpleRequestModel request = request();
+        request.setTransferDate(transferDate);
+
+        createInternalTransferSimpleServiceExecuteAssertions(request, "TransferDate");
+    }
+
     private void createInternalTransferSimpleServiceExecuteAssertions(final InternalTransferSimpleRequestModel request,
                                                                       final String field) throws JsonProcessingException {
         final String requestBody = new Gson().toJson(request);

--- a/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
+++ b/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
@@ -36,22 +36,6 @@ class CreateInternalTransferSimpleServiceTest {
         createInternalTransferSimpleServiceExecuteAssertions(request, "ToTaxNumber");
     }
 
-    @Test
-    void shouldGetNullWhenPassingInvalidValue() throws JsonProcessingException {
-        final InternalTransferSimpleRequestModel request = request();
-        request.setValue(null);
-
-        createInternalTransferSimpleServiceExecuteAssertions(request, "Value");
-    }
-
-    @Test
-    void shouldGetNullWhenPassingInvalidRateValue() throws JsonProcessingException {
-        final InternalTransferSimpleRequestModel request = request();
-        request.setRateValue(null);
-
-        createInternalTransferSimpleServiceExecuteAssertions(request, "RateValue");
-    }
-
     @ParameterizedTest
     @NullAndEmptySource
     void shouldGetNullWhenPassingInvalidTransferDate(final String transferDate) throws JsonProcessingException {
@@ -68,6 +52,31 @@ class CreateInternalTransferSimpleServiceTest {
         request.setIdentifier(identifier);
 
         createInternalTransferSimpleServiceExecuteAssertions(request, "Identifier");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldGetNullWhenPassingInvalidDescription(final String description) throws JsonProcessingException {
+        final InternalTransferSimpleRequestModel request = request();
+        request.setDescription(description);
+
+        createInternalTransferSimpleServiceExecuteAssertions(request, "Description");
+    }
+
+    @Test
+    void shouldGetNullWhenPassingInvalidValue() throws JsonProcessingException {
+        final InternalTransferSimpleRequestModel request = request();
+        request.setValue(null);
+
+        createInternalTransferSimpleServiceExecuteAssertions(request, "Value");
+    }
+
+    @Test
+    void shouldGetNullWhenPassingInvalidRateValue() throws JsonProcessingException {
+        final InternalTransferSimpleRequestModel request = request();
+        request.setRateValue(null);
+
+        createInternalTransferSimpleServiceExecuteAssertions(request, "RateValue");
     }
 
     private void createInternalTransferSimpleServiceExecuteAssertions(final InternalTransferSimpleRequestModel request,

--- a/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
+++ b/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
@@ -1,0 +1,58 @@
+package com.br.sellers.fitbank.mock.service.internaltransfer;
+
+import com.br.sellers.fitbank.mock.gateway.model.request.internaltransfer.InternalTransferSimpleRequestModel;
+import com.br.sellers.fitbank.mock.gateway.model.response.BasicResponseModel;
+import com.br.sellers.fitbank.mock.service.ServiceBase;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
+
+class CreateInternalTransferSimpleServiceTest {
+
+    private final ServiceBase createInternalTransferSimpleService = new CreateInternalTransferSimpleService();
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldGetNullWhenPassingInvalidFromTaxNumber(final String fromTaxNumber) throws JsonProcessingException {
+        final InternalTransferSimpleRequestModel request = request();
+        request.setFromTaxNumber(fromTaxNumber);
+
+        createInternalTransferSimpleServiceExecuteAssertions(request, "FromTaxNumber");
+    }
+
+    private void createInternalTransferSimpleServiceExecuteAssertions(final InternalTransferSimpleRequestModel request,
+                                                                      final String field) throws JsonProcessingException {
+        final String requestBody = new Gson().toJson(request);
+        final BasicResponseModel response = createInternalTransferSimpleService.execute(requestBody, "");
+
+        Assertions.assertNotNull(response);
+        Assertions.assertNotNull(response.getValidation());
+        Assertions.assertEquals(1, response.getValidation().length);
+
+        final Map<String, String> validation = (Map<String, String>) response.getValidation()[0];
+        Assertions.assertTrue(validation.containsKey(field));
+        Assertions.assertEquals(String.format("%s é obrigatório", field), validation.get(field));
+    }
+
+    private InternalTransferSimpleRequestModel request() {
+        final InternalTransferSimpleRequestModel request = new InternalTransferSimpleRequestModel();
+        request.setMethod("GetBoletoById");
+        request.setPartnerId(12345L);
+        request.setBusinessUnitId(1234567890L);
+        request.setFromTaxNumber("10000");
+        request.setToTaxNumber("200000");
+        request.setValue(BigDecimal.valueOf(1000L));
+        request.setRateValue(BigDecimal.valueOf(1000));
+        request.setTransferDate("01/01/2023");
+        request.setIdentifier(UUID.randomUUID().toString());
+        request.setDescription("Description");
+
+        return request;
+    }
+}

--- a/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
+++ b/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
@@ -26,6 +26,15 @@ class CreateInternalTransferSimpleServiceTest {
         createInternalTransferSimpleServiceExecuteAssertions(request, "FromTaxNumber");
     }
 
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldGetNullWhenPassingInvalidToTaxNumber(final String toTaxNumber) throws JsonProcessingException {
+        final InternalTransferSimpleRequestModel request = request();
+        request.setToTaxNumber(toTaxNumber);
+
+        createInternalTransferSimpleServiceExecuteAssertions(request, "ToTaxNumber");
+    }
+
     private void createInternalTransferSimpleServiceExecuteAssertions(final InternalTransferSimpleRequestModel request,
                                                                       final String field) throws JsonProcessingException {
         final String requestBody = new Gson().toJson(request);
@@ -45,6 +54,7 @@ class CreateInternalTransferSimpleServiceTest {
         request.setMethod("GetBoletoById");
         request.setPartnerId(12345L);
         request.setBusinessUnitId(1234567890L);
+
         request.setFromTaxNumber("10000");
         request.setToTaxNumber("200000");
         request.setValue(BigDecimal.valueOf(1000L));

--- a/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
+++ b/src/test/java/com/br/sellers/fitbank/mock/service/internaltransfer/CreateInternalTransferSimpleServiceTest.java
@@ -44,6 +44,14 @@ class CreateInternalTransferSimpleServiceTest {
         createInternalTransferSimpleServiceExecuteAssertions(request, "Value");
     }
 
+    @Test
+    void shouldGetNullWhenPassingInvalidRateValue() throws JsonProcessingException {
+        final InternalTransferSimpleRequestModel request = request();
+        request.setRateValue(null);
+
+        createInternalTransferSimpleServiceExecuteAssertions(request, "RateValue");
+    }
+
     private void createInternalTransferSimpleServiceExecuteAssertions(final InternalTransferSimpleRequestModel request,
                                                                       final String field) throws JsonProcessingException {
         final String requestBody = new Gson().toJson(request);


### PR DESCRIPTION
## Foi testado no Java 1.8 (Leia a Readme para entender)?
- [x] Sim

```
openjdk version "1.8.0_292"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_292-b10)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.292-b10, mixed mode)
```
 
## O que era pra ser feito?
Incluido regras de campos obrigatórios de acordo com a documentação https://fitbank.com.br/developer/#api-P2P-InternalTransfer

## Issue
[Criar regras de campos obrigatórios no InternalTransfer](https://github.com/Sellers-Community/fitbank-mock/issues/4)

## Tipo de alteração

Exclua as opções que não são relevantes.
- [X] Novo recurso
- [ ] Correção de bug

## Como isso foi testado?

- Através do teste unitário: ```CreateInternalTransferSimpleServiceTest```

- Executando as seguintes chamadas para o endpoint principal:

```
// Ok
curl --request POST \
  --url http://localhost:8031/main/execute \
  --header 'content-type: application/json' \
  --data '{
	"Method": "InternalTransfer",
	"PartnerId": 12345,
	"BusinessUnitId": 1234567890,
	"FromTaxNumber": "10000",
	"ToTaxNumber": "200000",
	"Value": 1000,
	"RateValue": 1000,
	"TransferDate": "01/01/2023",
	"Identifier": "7ac60e7d-ff88-4ee6-8563-e1c772565e04",
	"Description": "Description"
}'

// Para cada campo obrigatório deverá ser feito as chamadas abaixo. O exemplo utiliza o campo 'FromTaxNumber'

// FromTaxNumber vazio
curl --request POST \
  --url http://localhost:8031/main/execute \
  --header 'content-type: application/json' \
  --data '{
	"Method": "InternalTransfer",
	"PartnerId": 12345,
	"BusinessUnitId": 1234567890,
	"FromTaxNumber": "",
	"ToTaxNumber": "200000",
	"Value": 1000,
	"RateValue": 1000,
	"TransferDate": "01/01/2023",
	"Identifier": "7ac60e7d-ff88-4ee6-8563-e1c772565e04",
	"Description": "Description"
}'

// FromTaxNumber nulo
curl --request POST \
  --url http://localhost:8031/main/execute \
  --header 'content-type: application/json' \
  --data '{
	"Method": "InternalTransfer",
	"PartnerId": 12345,
	"BusinessUnitId": 1234567890,
	"FromTaxNumber": null,
	"ToTaxNumber": "200000",
	"Value": 1000,
	"RateValue": 1000,
	"TransferDate": "01/01/2023",
	"Identifier": "7ac60e7d-ff88-4ee6-8563-e1c772565e04",
	"Description": "Description"
}'

// FromTaxNumber não informado
curl --request POST \
  --url http://localhost:8031/main/execute \
  --header 'content-type: application/json' \
  --data '{
	"Method": "InternalTransfer",
	"PartnerId": 12345,
	"BusinessUnitId": 1234567890,
	"ToTaxNumber": "200000",
	"Value": 1000,
	"RateValue": 1000,
	"TransferDate": "01/01/2023",
	"Identifier": "7ac60e7d-ff88-4ee6-8563-e1c772565e04",
	"Description": "Description"
}'
```

