### PR TITLE
Criando regras de campos obrigatórios no GenerateBoleto.

### DIFF
--- a/src/main/java/com/br/sellers/fitbank/mock/service/paymentslip/CreatePaymentSlipService.java
+++ b/src/main/java/com/br/sellers/fitbank/mock/service/paymentslip/CreatePaymentSlipService.java
@@ -7,6 +7,7 @@ import com.br.sellers.fitbank.mock.gateway.model.response.paymentslip.GetPayment
 import com.br.sellers.fitbank.mock.service.ServiceBaseImpl;
 import com.google.gson.Gson;
 
+import java.util.Map;
 import java.util.Random;
 
 public class CreatePaymentSlipService extends ServiceBaseImpl {
@@ -30,4 +31,32 @@ public class CreatePaymentSlipService extends ServiceBaseImpl {
         modelResponde.setAlreadyExists(false);
     }
 
+    @Override
+    protected void validadeFields(BasicRequestModel request, Map<String, Object> errors) {
+        CreatePaymentSlipRequestModel model = (CreatePaymentSlipRequestModel) request;
+
+        validadeField(model.getGroupTemplate(), "GroupTemplate", "GroupTemplate é obrigatório", errors);
+        validadeField(model.getCustomerName(), "CustomerName", "CustomerName é obrigatório", errors);
+        validadeField(model.getCustomerTaxNumber(), "CustomerTaxNumber", "CustomerTaxNumber é obrigatório", errors);
+        validadeField(model.getCustomerMail(), "CustomerMail", "CustomerMail é obrigatório", errors);
+        validadeField(model.getCustomerPhone(), "CustomerPhone", "CustomerPhone é obrigatório", errors);
+        validadeField(model.getNeighborhood(), "Neighborhood", "Neighborhood é obrigatório", errors);
+        validadeField(model.getCity(), "City", "City é obrigatório", errors);
+        validadeField(model.getState(), "State", "State é obrigatório", errors);
+        validadeField(model.getZipCode(), "ZipCode", "ZipCode é obrigatório", errors);
+        validadeField(model.getSupplierTaxNumber(), "SupplierTaxNumber", "SupplierTaxNumber é obrigatório", errors);
+        validadeField(model.getSupplierFullName(), "SupplierFullName", "SupplierFullName é obrigatório", errors);
+        validadeField(model.getSupplierTradingName(), "SupplierTradingName", "SupplierTradingName é obrigatório", errors);
+        validadeField(model.getSupplierLegalName(), "SupplierLegalName", "SupplierLegalName é obrigatório", errors);
+        validadeField(model.getSupplierMail(), "SupplierMail", "SupplierMail é obrigatório", errors);
+        validadeField(model.getSupplierPhone(), "SupplierPhone", "SupplierPhone é obrigatório", errors);
+        validadeField(model.getRateValue(), "RateValue", "RateValue é obrigatório", errors);
+        validadeField(model.getRateSent    (), "RateSent", "RateSent é obrigatório", errors);
+        validadeField(model.getAddressLine1(), "AddressLine1", "AddressLine1 é obrigatório", errors);
+        validadeField(model.getExternalNumber(), "ExternalNumber", "ExternalNumber é obrigatório", errors);
+        validadeField(model.getIdentifier(), "Identifier", "Identifier é obrigatório", errors);
+        validadeField(model.getProducts(), "Products", "Products é obrigatório", errors);
+        validadeField(model.getDueDate(), "DueDate", "DueDate é obrigatório", errors);
+        validadeField(model.getTotalValue(), "TotalValue", "TotalValue é obrigatório", errors);
+    }
 }


### PR DESCRIPTION
# Pull Request Template

## Foi testado no Java 1.8 (Leia a Readme para entender)?
- [x] Sim
 
## O que era pra ser feito?

Implementação dos campos obrigatórios conforme documentação da Fitbank.

## Issue

https://github.com/Sellers-Community/fitbank-mock/issues/2

## Tipo de alteração

Exclua as opções que não são relevantes.

- [x] Novo recurso
- [ ] Correção de bug

## Como isso foi testado?

Teste através de requisição POST no Postman com o seguinte JSON:

{
  "Method": "GenerateBoleto",
  "PartnerId": 0,
  "BusinessUnitId": 0,
  "GroupTemplate": 2,
  "CustomerName": "Paula",
  "CustomerTaxNumber": "88899926655",
  "CustomerMail": "paularenatams@gmail.com",
  "CustomerPhone": "47988889999",
  "Neighborhood": "aririba",
  "City":"Balneario Camboriu",
  "State":"SC",
  "ZipCode":"88338480",
  "SupplierTaxNumber":"12345678910",
  "SupplierFullName":"teste",
  "SupplierTradingName":"teste",
  "SupplierLegalName":"teste",
  "SupplierMail":"teste@gmail.com",
  "SupplierPhone":"47988889999",
  "RateValue":10,
  "RateSent":true,
  "AddressLine1":"rua mergulhao, 90",
  "ExternalNumber":0,
  "Identifier":12,
  "DueDate":"2022/11/23",
  "TotalValue":123,
  "Products":[
      {
      "ProductCode":"123",
      "ProductName":"teste"
      }
  ]
}
